### PR TITLE
Make JOB_ID argument optional

### DIFF
--- a/lib/etl/cli/cmd/job.rb
+++ b/lib/etl/cli/cmd/job.rb
@@ -20,7 +20,7 @@ module ETL::Cli::Cmd
     end
 
     class Run < ETL::Cli::Command
-      parameter "JOB_ID", "ID of job we are running", required: true
+      parameter "JOB_ID", "ID of job we are running", required: false, default: ''
 
       option ['-b', '--batch'], "BATCH", "Batch for the job in JSON or 'key1=value1;key2=value2' format", attribute_name: :batch_str
       option ['-q', '--queue'], :flag, "Queue the job instead of running now"

--- a/spec/lib/etl/cli/cmd/job_spec.rb
+++ b/spec/lib/etl/cli/cmd/job_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ETL::Cli::Cmd::Job::Run do
         end
       end
       context 'matching all' do
-        let(:job_expr) { '' }
+        let(:args) { ['--match'] }
         it 'runs all jobs' do
           expect(subject).to receive(:run_batch)
             .exactly(2).times

--- a/spec/lib/etl/cli/cmd/job_spec.rb
+++ b/spec/lib/etl/cli/cmd/job_spec.rb
@@ -55,8 +55,17 @@ RSpec.describe ETL::Cli::Cmd::Job::Run do
       end
       context 'matching none' do
         let(:job_expr) { 'maze' }
-        it 'runs job' do
+        it 'runs no jobs' do
           expect{ subject.execute }.to raise_error(/no job/i)
+        end
+      end
+      context 'matching all' do
+        let(:job_expr) { '' }
+        it 'runs all jobs' do
+          expect(subject).to receive(:run_batch)
+            .exactly(2).times
+            .with(anything, an_instance_of(ETL::Batch))
+          subject.execute
         end
       end
     end


### PR DESCRIPTION
Need to do this so we can pass a match-all regex to run all jobs

(https://www.pivotaltracker.com/story/show/145774369)[#145774369]