### PR TITLE
Add job factory to enable custom job creation

### DIFF
--- a/lib/etl/cli/cmd/scheduler.rb
+++ b/lib/etl/cli/cmd/scheduler.rb
@@ -1,14 +1,15 @@
 require_relative '../command'
 require 'etl/job/manager'
+require 'etl/job/base'
 
 module ETL::Cli::Cmd
   # Class that handles putting scheduled jobs into the queue for execution
   class Scheduler < ETL::Cli::Command
-    
+
     option ["-p", "--pause"], "SECS", "seconds to pause between scheduling runs", default: 60 do |s|
       Float(s)
     end
-    
+
     def execute
       ETL.load_user_classes
       with_log do
@@ -17,41 +18,41 @@ module ETL::Cli::Cmd
         end
       end
     end
-    
+
     def job_manager
       ETL::Job::Manager.instance
     end
-    
+
     def run_iteration
       log.debug("Start scheduling iteration")
-      job_manager.each_class do |klass|
+      job_manager.job_classes.each do |job_id, klass|
         begin
-          process_job_class(klass)
+          process_job_class(job_id, klass)
         rescue StandardError => ex
           # Log and ignore all exceptions so that one job doesn't affect others
-          log.error("Scheduling job #{j.name} encountered an error")
+          log.error("Scheduling job #{job_id} encountered an error")
           log.exception(ex)
         end
       end
       log.debug("End scheduling iteration, sleeping for #{pause} seconds")
       sleep(pause)
     end
-    
+
     # Schedule a job class that has been registered with the manager. To do this
     # we must generate all batches for this job class and instantiate jobs
     # for each to check if they're ready.
-    def process_job_class(klass)
+    def process_job_class(job_id, klass)
       klass.batch_factory.each do |batch|
-        process_job(klass.new(batch))
+        process_job(::ETL::Job::Exec.create_job(job_id, klass, batch))
       end
     end
-    
+
     def process_job(job)
       unless job.schedule.ready?
         log.debug("Job #{job} not ready to run, skipping")
         return
       end
-      
+
       payload = ETL::Queue::Payload.new(job.id, job.batch)
       ETL.queue.enqueue(payload)
       log.info("Job #{job} ready to run, enqueued #{payload}")

--- a/lib/etl/job/manager.rb
+++ b/lib/etl/job/manager.rb
@@ -3,31 +3,46 @@ require 'singleton'
 module ETL::Job
   class Manager
     include Singleton
-    
+
     # Map of id => Class
-    attr_accessor :job_classes
-    
+    attr_accessor :job_classes, :job_class_factories
+
     def initialize
       @job_classes = {}
+      @job_class_factories = {}
     end
-    
+
     # Registers a job class with the manager. This is typically called by
     # subclasses to register themselves with a convenient id to represent
     # that subclass. Only registered jobs can be executed.
-    def register(id, klass)
+    def register(id, klass, klass_factory=nil)
       ETL.logger.debug("Registering job class with manager: #{id} => #{klass}")
       if @job_classes.has_key?(id)
         ETL.logger.warn("Overwriting previous registration of: #{id} => #{@job_classes[id]}")
       end
+
+      if !klass_factory.nil?
+        ETL.logger.debug("Registering job class factory with manager: #{id}")
+        if @job_classes.has_key?(id)
+          ETL.logger.warn("Overwriting previous registration of job factory: #{id}")
+        end
+        @job_class_factories[id] = klass_factory
+      end
+
       @job_classes[id] = klass
     end
-    
+
     # Returns the job class registered for the specified ID, or nil if none
     def get_class(id)
       @job_classes[id]
     end
-    
-    # Iterates through the loaded classes specified during class initailiation.
+
+    # Returns the job class factory registered for the specified ID, or nil if none
+    def get_class_factory(job_id)
+      @job_class_factories[job_id]
+    end
+
+    # Iterates through the loaded classes specified during class initialization.
     def each_class(&block)
       @job_classes.each do |id, klass|
         yield klass

--- a/lib/etl/job_factory/base.rb
+++ b/lib/etl/job_factory/base.rb
@@ -1,0 +1,17 @@
+require 'mixins/cached_logger'
+
+module ETL::JobFactory
+
+  # Base class for all job factories that are run
+  # enables one job to represent multiple jobs in a
+  # data driven way.
+  class Base
+    include ETL::CachedLogger
+
+    # create can create a specified job
+    def create(job_id, batch)
+      klass = ::ETL::Job::Manager.instance.get_class(job_id)
+      klass.new(batch)
+    end
+  end
+end

--- a/spec/job/manager_spec.rb
+++ b/spec/job/manager_spec.rb
@@ -1,0 +1,63 @@
+require 'etl'
+require 'etl/job_factory/base'
+require 'etl/job/base'
+require 'etl/job/exec'
+require 'etl/job/manager'
+
+module ManagerTests
+
+  # Test job should now be able to be registered
+  # via the factory
+  class TestJob < ETL::Job::Base
+    attr_accessor :p1
+    def initialize(batch, id, p1)
+      super(batch)
+      @p1 = p1
+      @id = id
+    end
+    def id
+      @id
+    end
+  end
+
+  class TestJob2 < ETL::Job::Base
+    def initialize(b)
+      super(b)
+    end
+  end
+
+  class TestJobFactory < ::ETL::JobFactory::Base
+    def create(job_id, batch)
+      klass = ::ETL::Job::Manager.instance.get_class(job_id)
+      klass.new(batch, job_id, "1")
+    end
+  end
+end
+RSpec.describe "manager" do
+  context "job factory" do
+    it "register job with its factory and and create it" do
+      manager = ::ETL::Job::Manager.instance
+      tjf = ManagerTests::TestJobFactory.new
+      test_job_klass = Object.const_get("ManagerTests").const_get("TestJob")
+      manager.register("TestJob1", test_job_klass, tjf)
+      manager.register("TestJob2", test_job_klass, tjf)
+      f = manager.get_class_factory("TestJob1")
+      expect(f).to eq(tjf)
+
+      # ensure the job can be creates leveraging the job factory
+      job = ETL::Job::Exec.create_job("TestJob1", test_job_klass, ETL::Batch.new)
+      expect(job.p1).to eq("1")
+    end
+
+    it "register job with no job factory and create it" do
+      manager = ::ETL::Job::Manager.instance
+      tj = ManagerTests::TestJob2.new(::ETL::Batch.new)
+      manager.register(tj.id, tj.class)
+      f = manager.get_class_factory(tj.id)
+      expect(f).to eq(nil)
+      # ensure the job can be creates leveraging the job factory
+      job = ETL::Job::Exec.create_job(tj.id, tj.class, ETL::Batch.new)
+    end
+  end
+end
+

--- a/spec/job/manager_spec.rb
+++ b/spec/job/manager_spec.rb
@@ -13,17 +13,14 @@ module ManagerTests
     def initialize(batch, id, p1)
       super(batch)
       @p1 = p1
-      @id = id
+      @job_id = id
     end
     def id
-      @id
+      @job_id
     end
   end
 
   class TestJob2 < ETL::Job::Base
-    def initialize(b)
-      super(b)
-    end
   end
 
   class TestJobFactory < ::ETL::JobFactory::Base


### PR DESCRIPTION
Job factory enables the ability to create multiple jobs from one base
job. It allows a job's initialize to take custom parameters in fed from
the factory.

1) Updated the manager to add a job factory with the associated job when
needed and added tests

2) Updated the cli job run and scheduler to ensure they can run and
schedule correctly