### PR TITLE
Remove assume_role code

### DIFF
--- a/lib/etl/core.rb
+++ b/lib/etl/core.rb
@@ -42,31 +42,6 @@ base_file = 'base.rb'
 end
 
 module ETL
-  # creates aws credentials to log
-  def self.create_aws_credentials(region, iam_role, session_name)
-    if ENV["TEST_AWS_ACCESS_KEY_ID"].nil?
-      sts = Aws::STS::Client.new(region: region)
-      session = sts.assume_role(
-        role_arn: iam_role,
-        role_session_name: session_name
-      )
-
-      creds = Aws::Credentials.new(
-        session.credentials.access_key_id,
-        session.credentials.secret_access_key,
-        session.credentials.session_token
-      )
-    else
-      # Note this branch of code is really for testing purposes
-      # when running from a machine that is not an ec2 instance
-      # which is why TEST is affixed ahead of it
-      creds = Aws::Credentials.new(
-         ENV["TEST_AWS_ACCESS_KEY_ID"],
-         ENV["TEST_AWS_SECRET_ACCESS_KEY"]
-      )
-    end
-  end
-
   # Generic App-wide logger
   def ETL.logger
     @@logger ||= ETL.create_logger

--- a/lib/etl/output/redshift.rb
+++ b/lib/etl/output/redshift.rb
@@ -105,18 +105,13 @@ SQL
       @client.execute(sql)
     end
 
-    def creds
-      session_name = "rdshift-#{tmp_table[0..49]}-upload"
-      ::ETL.create_aws_credentials(@aws_params[:region], @aws_params[:role_arn], session_name)
-    end
-
     def upload_to_s3
-      s3_resource = Aws::S3::Resource.new(region: @aws_params[:region], credentials: creds)
+      s3_resource = Aws::S3::Resource.new(region: @aws_params[:region])
       s3_resource.bucket(@bucket).object(tmp_table).upload_file(csv_file.path)
     end
 
     def delete_object_from_s3
-      s3_client = Aws::S3::Client.new(region: @aws_params[:region], credentials: creds)
+      s3_client = Aws::S3::Client.new(region: @aws_params[:region])
       s3_response = s3_client.delete_object({
         bucket: @bucket,
         key: tmp_table

--- a/lib/etl/queue/sqs.rb
+++ b/lib/etl/queue/sqs.rb
@@ -13,11 +13,8 @@ module ETL::Queue
       idle_timeout = params.fetch(:idle_timeout, nil)
       @queue_url = params.fetch(:url, '')
       @region = params.fetch(:region, '')
-      @iam_role = params.fetch(:iam_role, '')
 
-      creds = ::ETL.create_aws_credentials(@region, @iam_role, "etl_sqs_session")
-
-      @client = Aws::SQS::Client.new(region: @region, credentials: creds)
+      @client = Aws::SQS::Client.new(region: @region)
       @poller = Aws::SQS::QueuePoller.new(@queue_url, { client: @client, idle_timeout: idle_timeout })
       @queue = Aws::SQS::Queue.new(url: @queue_url, client: @client)
 


### PR DESCRIPTION
Remove `create_aws_credentials` and all `assume_role` logic. From now on, let the SDK figure out what credentials to use (instance profile, etc).