### PR TITLE
Skip when adding rows to tables with 0 rows

### DIFF
--- a/lib/etl/redshift/client.rb
+++ b/lib/etl/redshift/client.rb
@@ -205,8 +205,8 @@ SQL
       add_rows(reader, table_schemas_lookup, row_transformer, validator,  AddNewData.new("append")) 
     end
 
-    # Upserts rows into the destintation tables based on rows
-    # provided by the reader.
+    # adds rows into the destintation tables based on rows
+    # provided by the reader and their add data type.
     def add_rows(reader, table_schemas_lookup, row_transformer, validator = nil, add_new_data)
       tmp_session = table_schemas_lookup.keys.join('_') + SecureRandom.hex(5)
 

--- a/lib/etl/redshift/client.rb
+++ b/lib/etl/redshift/client.rb
@@ -22,8 +22,8 @@ module ETL::Redshift
       @region = aws_params.fetch(:region)
       @bucket = aws_params.fetch(:s3_bucket)
       @iam_role = aws_params.fetch(:role_arn)
-      @random_key = [*('a'..'z'), *('0'..'9')].sample(10).join
       @delimiter = "\u0001"
+
       # note the host is never specified as its part of the dsn name and for now that is hardcoded as 'MyRealRedshift'
       password = conn_params.fetch(:password)
       dsn = conn_params.fetch(:dsn, 'MyRealRedshift')
@@ -196,7 +196,19 @@ SQL
     # Upserts rows into the destintation tables based on rows
     # provided by the reader.
     def upsert_rows(reader, table_schemas_lookup, row_transformer, validator = nil)
-      tmp_session = table_schemas_lookup.keys.join('_') + @random_key
+      add_rows(reader, table_schemas_lookup, row_transformer, validator,  AddNewData.new("upsert"))
+    end
+
+    # Appends rows into the destintation tables based on rows
+    # provided by the reader.
+    def append_rows(reader, table_schemas_lookup, row_transformer, validator = nil)
+      add_rows(reader, table_schemas_lookup, row_transformer, validator,  AddNewData.new("append")) 
+    end
+
+    # Upserts rows into the destintation tables based on rows
+    # provided by the reader.
+    def add_rows(reader, table_schemas_lookup, row_transformer, validator = nil, add_new_data)
+      tmp_session = table_schemas_lookup.keys.join('_') + SecureRandom.hex(5)
 
       # Remove new lines ensures that all row values have newlines removed.
       remove_new_lines = ::ETL::Transform::RemoveNewlines.new
@@ -206,12 +218,13 @@ SQL
       csv_files = {}
       csv_file_paths = {}
       file_uploaded = {}
+      rows_processed_map = {}
       table_schemas_lookup.keys.each do |t|
         csv_file_paths[t] = temp_file(t)
         csv_files[t] = ::CSV.open(csv_file_paths[t], 'w', col_sep: @delimiter)
+        rows_processed_map[t] = 0
       end
 
-      rows_processed = 0
       begin
         reader.each_row do |row|
           values_lookup = transform_row(table_schemas_lookup, row_transformers, row)
@@ -222,12 +235,17 @@ SQL
             row_arrays.each do |values_arr|
               csv_row = CSV::Row.new(table_schema.columns.keys, values_arr)
               csv_files[table_name].add_row(csv_row)
-              rows_processed += 1
+              rows_processed_map[table_name] += 1
             end
           end
         end
       ensure
         table_schemas_lookup.each_pair do |t, table_schema|
+          if rows_processed_map[t] == 0
+            log.debug("table #{t} has zero rows no upload required")
+            next
+          end
+
           csv_files[t].close
           local_file_path = csv_file_paths[t]
           s3_file_name = File.basename(local_file_path)
@@ -252,21 +270,20 @@ SQL
           end
 
           validator.validate(t, tmp_table, table_schema) if validator
-          # Using recommended method to do upsert
-          # http://docs.aws.amazon.com/redshift/latest/dg/merge-replacing-existing-rows.html
-          upsert_data = <<SQL
-begin transaction;
-  delete from #{full_table} using #{tmp_table} #{where_id_join};
-  insert into #{full_table} select * from #{tmp_table};
-end transaction;
-SQL
-          execute(upsert_data)
+          add_sql = add_new_data.build_sql(tmp_table, full_table, { where_id_join: where_id_join })
+          execute(add_sql)
           if file_uploaded[t]
             s3_resource.bucket(@bucket).object(s3_file_name).delete()
           end
         end
       end
-      rows_processed
+      highest_num_rows_processed = 0
+
+      # might need to do something different but doing this for now.
+      rows_processed_map.each_pair do |_key, value|
+        highest_num_rows_processed = value if highest_num_rows_processed < value
+      end
+      highest_num_rows_processed
     end
 
     def table_exists?(schema, table_name)
@@ -276,7 +293,7 @@ SQL
     end
 
     def create_staging_table(final_table_schema, final_table_name)
-      tmp_table_name = final_table_name + @random_key
+      tmp_table_name = final_table_name + SecureRandom.hex(5)
       # create temp table to add data to.
       tmp_table = ::ETL::Redshift::Table.new(tmp_table_name, temp: true, like: "#{final_table_schema}.#{final_table_name}")
       create_table(tmp_table)
@@ -326,6 +343,37 @@ SQL
       values_by_table
     end
   end
+
+  class AddNewData
+    def initialize(add_data_type)
+      @add_data_type = add_data_type
+    end
+
+    def build_sql(tmp_table, destination_table_name, opts)
+      sql = ""
+      if @add_data_type == "append"
+          sql = <<SQL
+begin transaction;
+  insert into #{destination_table_name} select * from #{tmp_table};
+end transaction;
+SQL
+      elsif @add_data_type == "upsert"
+          where_id_join = opts.fetch(:where_id_join)
+          # Using recommended method to do upsert
+          # http://docs.aws.amazon.com/redshift/latest/dg/merge-replacing-existing-rows.html
+          sql = <<SQL
+begin transaction;
+  delete from #{destination_table_name} using #{tmp_table} #{where_id_join};
+  insert into #{destination_table_name} select * from #{tmp_table};
+end transaction;
+SQL
+      else
+        raise "Unknown add data type #{@add_data_type}"
+      end
+      sql
+    end
+  end
+
   # class used as sentinel to skip a row.
   class SkipRow
   end

--- a/spec/redshift/client_spec.rb
+++ b/spec/redshift/client_spec.rb
@@ -108,42 +108,6 @@ SQL
       expect(values).to eq([{:id=>1, :col2=>"value2a"}, {:id=>3, :col2=>"value2b"}])
     end
 
-    it 'upsert data into two tables with splitter' do
-      client.drop_table('simple_orgs_2')
-      client.drop_table('simple_orgs_history')
-      create_table = <<SQL
-  create table simple_orgs_2 (
-    id integer,
-    col2 varchar(20),
-    PRIMARY KEY(id) );
-
-  create table simple_orgs_history (
-    h_id integer,
-    id integer,
-    PRIMARY KEY(h_id) );
-SQL
-      client.execute(create_table)
-      data = [
-        { :h_id => 4, :id => 1, :col2 => 'value2a' },
-        { :h_id => 5, :id => 2, :col2 => 'value2b' },
-        { :h_id => 6, :id => 3, :col2 => 'value2c' }
-      ]
-      input = ETL::Input::Array.new(data)
-      simple_orgs_schema = client.table_schema('simple_orgs_2')
-      simple_orgs_history_schema = client.table_schema('simple_orgs_history')
-      row_splitter = ::ETL::Transform::SplitRow.SplitByTableSchemas([simple_orgs_schema, simple_orgs_history_schema])
-      client.upsert_rows(input, { 'simple_orgs_2' => simple_orgs_schema, 'simple_orgs_history' => simple_orgs_history_schema }, row_splitter)
-      r = client.fetch('Select * from simple_orgs_2 order by id')
-      values = []
-      r.map{ |v| values << v }
-      expect(values).to eq([{:id=>1, :col2=>"value2a"}, {:id=>2, :col2=>"value2b"}, {:id=>3, :col2=>"value2c"}])
-
-      r = client.fetch('Select * from simple_orgs_history order by h_id')
-      values = []
-      r.map{ |v| values << v }
-      expect(values).to eq([{:h_id=>4, :id=>1}, {:h_id=>5, :id=>2}, {:h_id=>6, :id=>3}])
-    end
-
     it 'upsert data into one table' do
       client.drop_table('simple_orgs')
       create_table = <<SQL

--- a/spec/redshift/client_spec.rb
+++ b/spec/redshift/client_spec.rb
@@ -76,6 +76,74 @@ SQL
       expect(rows).to eq([{:column=>"day", :type=>"timestamp without time zone"}])
     end
 
+    it 'append data into one table' do
+      client.drop_table('simple_table_foo')
+      create_table = <<SQL
+  create table simple_table_foo (
+    id integer,
+    col2 varchar(20),
+    PRIMARY KEY(id) );
+SQL
+      client.execute(create_table)
+      data = [
+        { :id => 1, :col2 => 'value2a' },
+      ]
+      input = ETL::Input::Array.new(data)
+      simple_orgs_schema = client.table_schema('simple_table_foo')
+      client.append_rows(input, { 'simple_table_foo' => simple_orgs_schema }, nil)
+      r = client.fetch('Select * from simple_table_foo order by id')
+      values = []
+      r.map{ |v| values << v }
+      expect(values).to eq([{:id=>1, :col2=>"value2a"}])
+
+      data = [
+        { :id => 3, :col2 => 'value2b' },
+      ]
+      input2 = ETL::Input::Array.new(data)
+
+      client.append_rows(input2, { 'simple_table_foo' => simple_orgs_schema }, nil)
+      r = client.fetch('Select * from simple_table_foo order by id')
+      values = []
+      r.map{ |v| values << v }
+      expect(values).to eq([{:id=>1, :col2=>"value2a"}, {:id=>3, :col2=>"value2b"}])
+    end
+
+    it 'upsert data into two tables with splitter' do
+      client.drop_table('simple_orgs_2')
+      client.drop_table('simple_orgs_history')
+      create_table = <<SQL
+  create table simple_orgs_2 (
+    id integer,
+    col2 varchar(20),
+    PRIMARY KEY(id) );
+
+  create table simple_orgs_history (
+    h_id integer,
+    id integer,
+    PRIMARY KEY(h_id) );
+SQL
+      client.execute(create_table)
+      data = [
+        { :h_id => 4, :id => 1, :col2 => 'value2a' },
+        { :h_id => 5, :id => 2, :col2 => 'value2b' },
+        { :h_id => 6, :id => 3, :col2 => 'value2c' }
+      ]
+      input = ETL::Input::Array.new(data)
+      simple_orgs_schema = client.table_schema('simple_orgs_2')
+      simple_orgs_history_schema = client.table_schema('simple_orgs_history')
+      row_splitter = ::ETL::Transform::SplitRow.SplitByTableSchemas([simple_orgs_schema, simple_orgs_history_schema])
+      client.upsert_rows(input, { 'simple_orgs_2' => simple_orgs_schema, 'simple_orgs_history' => simple_orgs_history_schema }, row_splitter)
+      r = client.fetch('Select * from simple_orgs_2 order by id')
+      values = []
+      r.map{ |v| values << v }
+      expect(values).to eq([{:id=>1, :col2=>"value2a"}, {:id=>2, :col2=>"value2b"}, {:id=>3, :col2=>"value2c"}])
+
+      r = client.fetch('Select * from simple_orgs_history order by h_id')
+      values = []
+      r.map{ |v| values << v }
+      expect(values).to eq([{:h_id=>4, :id=>1}, {:h_id=>5, :id=>2}, {:h_id=>6, :id=>3}])
+    end
+
     it 'upsert data into one table' do
       client.drop_table('simple_orgs')
       create_table = <<SQL


### PR DESCRIPTION
Also add append row capability and tests. Found a bug in that we should
always regenerate the staging table otherwise we can get into a
situation where multiple client operations use the same one.

[DW-362]