### PR TITLE
more detail retry message

### DIFF
--- a/lib/etl/job/exec.rb
+++ b/lib/etl/job/exec.rb
@@ -6,7 +6,8 @@ module ETL::Job
   class RetryError < StandardError
     attr_accessor :inner_error
     def initialize(inner_error, msg="A Retry error has occured")
-      super(msg)
+      error_msg = "#{meg}: #{inner_error.message}"
+      super(error_msg)
       @inner_error = inner_error
     end
   end


### PR DESCRIPTION
[DW-467]

inner_message goes to log, not slack, so we cannot see retry error message on slack 