### PR TITLE
Integrated Sanctify to keep secrets out of the repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     sha: v0.8.0
     hooks:
-    -   id: detect-aws-credentials 
-    -   id: detect-private-key 
+    -   id: detect-aws-credentials
+    -   id: detect-private-key
+-   repo: https://github.com/getoutreach/sanctify
+    sha: f16b0b2a560fe87f5ad5503da561a47be76f8956
+    hooks:
+    -   id: sanctify


### PR DESCRIPTION
Adds extra protection against AWS keys and other secrets so long as `pre-commit install` has been run locally. This Gem is much stricter than the pre-commit defaults that only check for existence of a credential file or environment variable. Sanctify matches common patterns of AWS secret keys, etc. 