### PR TITLE
Create an ETL command to write job status

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
       ruby-odbc
       sequel
       slack-notifier
+      terminal-table
       tzinfo
       tzinfo-data
 
@@ -23,13 +24,13 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     amq-protocol (2.2.0)
-    aws-sdk (2.10.95)
-      aws-sdk-resources (= 2.10.95)
-    aws-sdk-core (2.10.95)
+    aws-sdk (2.10.116)
+      aws-sdk-resources (= 2.10.116)
+    aws-sdk-core (2.10.116)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.95)
-      aws-sdk-core (= 2.10.95)
+    aws-sdk-resources (2.10.116)
+      aws-sdk-core (= 2.10.116)
     aws-sigv4 (1.0.2)
     bunny (2.7.0)
       amq-protocol (>= 2.2.0)
@@ -45,7 +46,7 @@ GEM
     jmespath (1.3.1)
     minitest (5.10.3)
     mysql2 (0.4.10)
-    pg (0.21.0)
+    pg (1.0.0)
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -56,14 +57,17 @@ GEM
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
     ruby-odbc (0.99998)
-    sequel (5.3.0)
-    slack-notifier (2.3.1)
+    sequel (5.4.0)
+    slack-notifier (2.3.2)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     time-warp (1.0.15)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     tzinfo-data (1.2017.3)
       tzinfo (>= 1.0.0)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
@@ -79,4 +83,4 @@ DEPENDENCIES
   time-warp
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/etl.gemspec
+++ b/etl.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pg'
   spec.add_dependency 'aws-sdk', ['>= 2.0', '< 3.0']
   spec.add_dependency 'slack-notifier'
+  spec.add_dependency 'terminal-table'
 
   spec.add_development_dependency 'bunny'
   spec.add_development_dependency 'factory_girl'

--- a/lib/etl/cli/cmd/job.rb
+++ b/lib/etl/cli/cmd/job.rb
@@ -8,14 +8,14 @@ require 'terminal-table'
 module ETL::Cli::Cmd
   class Job < ETL::Cli::Command
     class Status < ETL::Cli::Command
-      option ['-s', '--start-time'], 'STARTTIME', 'Will query for any jobs starting for a specified start time. Optional parameter, defaults to 2 hours before now', attribute_name: :start_time
+      option ['-s', '--start-time'], 'STARTTIME', 'Will query for any jobs starting for a specified start time. Optional parameter, defaults to 1 hour before now', attribute_name: :start_time
       option ['-t', '--type'], 'TYPE', 'Will query for any jobs with the specified status, defaults to running', attribute_name: :status
-      option ['-e', '--exclude-properties'], 'PROPERTIES', 'Removes specified properties from complete list, default is none', attribute_name: :excluded_properties
-      option ['-i', '--include-properties'], 'PROPERTIES', 'Includes only specified properties, default is none', attribute_name: :included_properties
+      option ['-e', '--exclude-properties'], 'PROPERTIES', 'Removes specified properties from complete list, default is nil', attribute_name: :excluded_properties
+      option ['-i', '--include-properties'], 'PROPERTIES', 'Includes only specified properties, default is nil', attribute_name: :included_properties
       option ['-f', '--format'], 'FORMAT', "Format of the output, can be 'table' or 'json', defaults to 'json'", attribute_name: :format
 
       def execute
-        @start_time = Time.now - 2 * 60 * 60 if @start_time.nil?
+        @start_time = Time.now - 1 * 60 * 60 if @start_time.nil?
         @status = 'running' if @status.nil?
         @format = 'json' if @format.nil?
 

--- a/lib/etl/models/job_run.rb
+++ b/lib/etl/models/job_run.rb
@@ -4,8 +4,17 @@ require 'etl/mixins/cached_logger'
 
 module ETL::Model
   class JobRun
+    class << self
+      def symbolized_properties
+        %i[id created_at update_at job_id batch status queued_at started_at updated_at ended_at rows_processed message]
+      end
+
+      def properties
+        symbolized_properties.map { |p| p.to_s.sub(':', '') }
+      end
+    end
     include ETL::CachedLogger
-    attr_accessor :id, :created_at, :update_at, :job_id, :batch, :status, :queued_at, :started_at, :updated_at, :ended_at, :rows_processed, :message
+    attr_accessor(*symbolized_properties)
 
     def initialize(repository)
       @repository = repository
@@ -13,20 +22,14 @@ module ETL::Model
 
     def to_h
       hash = {}
-      self.instance_variables.each do |var|
-        next if var.to_s == "@repository"
-        hash[var.to_s.gsub!('@','')] = self.instance_variable_get var
+      JobRun.properties.each do |p|
+        hash[p] = instance_variable_get "@#{p}"
       end
       hash
     end
 
-    def to_json(generator_state)
-        hash = to_h
-        hash.to_json
-    end
-
     def success?
-      self.status == :success
+      status == :success
     end
 
     # Sets the final status as success along with rows affected
@@ -53,7 +56,7 @@ module ETL::Model
     end
 
     # Sets the current status as queued and sets queued_at
-    def queued()
+    def queued
       self.status = :queued
       self.queued_at = Time.now
       self.updated_at = Time.now
@@ -61,6 +64,7 @@ module ETL::Model
     end
 
     private
+
     def final_state(state, result)
       self.status = state
       self.updated_at = Time.now

--- a/lib/etl/models/job_run.rb
+++ b/lib/etl/models/job_run.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'etl'
 require 'etl/mixins/cached_logger'
 
@@ -9,7 +10,21 @@ module ETL::Model
     def initialize(repository)
       @repository = repository
     end
-    
+
+    def to_h
+      hash = {}
+      self.instance_variables.each do |var|
+        next if var.to_s == "@repository"
+        hash[var.to_s.gsub!('@','')] = self.instance_variable_get var
+      end
+      hash
+    end
+
+    def to_json(generator_state)
+        hash = to_h
+        hash.to_json
+    end
+
     def success?
       self.status == :success
     end

--- a/lib/etl/models/job_run_repository.rb
+++ b/lib/etl/models/job_run_repository.rb
@@ -147,6 +147,16 @@ module ETL::Model
       job_run_query(sql)
     end
 
+    # Finds all batches currently of a specified status starting from the time specified
+    # If a job was aborted sometimes its not noted as completed in the database so
+    # only looking at jobs from a certain time forward. Default is now - 6 hours
+    # which can be re-configured
+    def find_by_status(status, initial_start_time)
+      initial_start_time = Time.now - 6 * 60 * 60 if initial_start_time.nil?
+      sql = "Select * from #{@schema_name}.job_runs where status = '#{status}' and started_at > '#{initial_start_time}';"
+      job_run_query(sql)
+    end
+
     # Returns true if this job+batch has pending jobs
     def has_pending?(job, batch)
       sql = "Select count(*) from #{@schema_name}.job_runs where job_id = '#{job.id}' and batch = '#{batch.to_json}' and ( status = 'queued' or status = 'running' );"

--- a/lib/etl/models/job_run_repository.rb
+++ b/lib/etl/models/job_run_repository.rb
@@ -149,10 +149,10 @@ module ETL::Model
 
     # Finds all batches currently of a specified status starting from the time specified
     # If a job was aborted sometimes its not noted as completed in the database so
-    # only looking at jobs from a certain time forward. Default is now - 6 hours
+    # only looking at jobs from a certain time forward. Default is now - 1 hour
     # which can be re-configured
     def find_by_status(status, initial_start_time)
-      initial_start_time = Time.now - 6 * 60 * 60 if initial_start_time.nil?
+      initial_start_time = Time.now - 1 * 60 * 60 if initial_start_time.nil?
       sql = "Select * from #{@schema_name}.job_runs where status = '#{status}' and started_at > '#{initial_start_time}';"
       job_run_query(sql)
     end

--- a/lib/etl/util/logger.rb
+++ b/lib/etl/util/logger.rb
@@ -9,6 +9,9 @@ module ETL
     def initialize(params = {})
       super(params[:file] || STDOUT)
       self.level = self.class.string_to_severity(params[:level])
+      level_str = ENV["ETL_LOG_LEVEL"]
+      env_level = self.class.string_to_severity(level_str) unless level_str.nil?
+      self.level = env_level unless env_level.nil?
       @formatter = Formatter.new
     end
     


### PR DESCRIPTION
[DW-492]
1) Added a job status command that can be used to find all jobs that
match a status starting from a particular time
2) Can write out in table format or json