### PR TITLE
Updated secret check hook to match main app

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,10 @@ repos:
     hooks:
     -   id: detect-aws-credentials
     -   id: detect-private-key
--   repo: https://github.com/getoutreach/sanctify
-    sha: f16b0b2a560fe87f5ad5503da561a47be76f8956
+-   repo: local
     hooks:
-    -   id: sanctify
+    -   id: secret-check-hook
+        name: "Sanctify Secret Scanner"
+        entry: ./bin/secret-check
+        language: script
+        files: .

--- a/bin/secret-check
+++ b/bin/secret-check
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Downloads and installs the Outreach fork of Sanctify.
+# NOTE: We tried to integrate the repo directly into pre-commit, but alas,
+# there is some weirdness with how pre-commit handles building and calling
+# gems from the context of a Rails app giving errors to certain users.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [[ ! $(which sanctify) ]]; then
+  git clone git://github.com/getoutreach/sanctify /tmp/sanctify
+  pushd /tmp/sanctify
+  package=$(gem build sanctify.gemspec 2>&1 | tail -1 | cut -d':' -f2 | tr -d ' ')
+  gem install $package
+  popd
+fi
+
+# NOTE: If you want to ignore certain files:
+# sanctify -c $DIR/sanctify.yml
+
+sanctify


### PR DESCRIPTION
Some users had issues with RBenv conflicts on the other apps due to the way precommit works. Just as a precautionary measure, lets keep parity with other outreach apps.