### PR TITLE
A number of env var fixes for env var

### DIFF
--- a/lib/etl/config.rb
+++ b/lib/etl/config.rb
@@ -10,11 +10,14 @@ module ETL
     include Singleton
 
     def initialize
-      @config_dir = ENV['ETL_CONFIG_DIR'] || File.expand_path('../../../etc', __FILE__)
+    end
+
+    def config_dir
+      ENV['ETL_CONFIG_DIR'] || File.expand_path('../../../etc', __FILE__)
     end
 
     def db_file
-      @config_dir + '/database.yml'
+      config_dir + '/database.yml'
     end
 
     def db
@@ -41,7 +44,7 @@ module ETL
     end
 
     def aws_file
-      @config_dir + '/aws.yml'
+      config_dir + '/aws.yml'
     end
 
     def aws
@@ -71,7 +74,7 @@ module ETL
     end
 
     def redshift_file
-      @config_dir + '/redshift.yml'
+      config_dir + '/redshift.yml'
     end
 
     def redshift
@@ -87,7 +90,7 @@ module ETL
     end
 
     def influx_file
-      @config_dir + '/influx.yml'
+      config_dir + '/influx.yml'
     end
 
     def influx
@@ -119,7 +122,7 @@ module ETL
     end
 
     def core_file
-      @config_dir + '/core.yml'
+      config_dir + '/core.yml'
     end
 
     def core
@@ -176,10 +179,12 @@ module ETL
     def rabbitmq_env_vars
       hash = {}
       # rabbitmq queue parameters
-      hash[:amqp_uri] = ENV.fetch('ETL_RABBIT_URI', nil)
+      amqp_uri = ENV.fetch('ETL_RABBIT_URI', nil)
+      hash[:amqp_uri] = amqp_uri unless amqp_uri.nil?
+
       hash[:host] = ENV.fetch('ETL_RABBIT_HOST', '127.0.0.1')
       hash[:port] = ENV.fetch('ETL_RABBIT_PORT', 5672)
-      hash[:user] = ENV.fetch('ETL_RABBIT_USERNAME', 'guest')
+      hash[:username] = ENV.fetch('ETL_RABBIT_USERNAME', 'guest')
       hash[:password] = ENV.fetch('ETL_RABBIT_PASSWORD', 'guest')
       hash[:heartbeat] = ENV.fetch('ETL_RABBIT_HEARTBEAT', 30)
       hash[:vhost] = ENV.fetch('ETL_RABBIT_VHOST', '/')

--- a/lib/etl/queue/rabbitmq.rb
+++ b/lib/etl/queue/rabbitmq.rb
@@ -9,15 +9,17 @@ module ETL::Queue
     def initialize(params)
       @params = params
       amqp_uri = params[:amqp_uri]
-      if ampq_uri.nil? then
-        @conn = Bunny.new(params[:host],
+      if amqp_uri.nil? then
+        opts = {
+          host: params[:host],
           port: params[:port],
           heartbeat: params[:heartbeat],
           vhost: params[:vhost],
           threaded: params.fetch(:threaded, true),
-          user: params[:username],
+          username: params[:username],
           password: params[:password],
-        )
+        }
+        @conn = Bunny.new(nil, opts)
       else
         @conn = Bunny.new(amqp_uri,
           heartbeat: params[:heartbeat],

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'secrets' do
   context 'validate rabbit mq env vars' do
     it 'Expect rabbitmq values come back correctly' do
       values = ::ETL.config.rabbitmq_env_vars
-      expect(values).to eq ({ amqp_uri: nil, host: '127.0.0.1', port: 5672, user: 'guest',
+      expect(values).to eq ({ host: '127.0.0.1', port: 5672, username: 'guest',
                               password: 'guest', heartbeat: 30, vhost: '/', channel_pool_size: 1,
                               prefetch_count: 1, queue: nil })
     end
@@ -50,22 +50,24 @@ RSpec.describe 'secrets' do
         ENV['ETL_DATA_DIR'] = saved_data_dir
       end
     end
-
-    it 'Expect rabbitmq queue defaults values come back core with rabbit set' do
+    
+    it 'Expect rabbitmq queue values come back core with rabbit set' do
       ::ETL.config.core_saved = nil
       saved_value = ENV['ETL_CORE_ENVVARS']
       saved_queue_class = ENV['ETL_QUEUE_CLASS']
       saved_db_password = ENV['ETL_DATABASE_PASSWORD']
       saved_data_dir = ENV['ETL_DATA_DIR']
+      saved_host = ENV['ETL_RABBIT_HOST']
       begin
         ENV['ETL_CORE_ENVVARS'] = 'TRUE'
         ENV['ETL_QUEUE_CLASS'] = '::ETL::Queue::RabbitMQ'
         ENV['ETL_DATABASE_PASSWORD'] = 'test'
         ENV['ETL_DATA_DIR'] = './'
+        ENV['ETL_RABBIT_HOST'] = 'foobar'
         values = ::ETL.config.core
-        expect(values[:queue]).to eq ({ amqp_uri: nil, channel_pool_size: 1,
-                                        host: '127.0.0.1', port: 5672,
-                                        user: 'guest', password: 'guest',
+        expect(values[:queue]).to eq ({ channel_pool_size: 1,
+                                        host: 'foobar', port: 5672,
+                                        username: 'guest', password: 'guest',
                                         heartbeat: 30, prefetch_count: 1,
                                         queue: nil,
                                         class: '::ETL::Queue::RabbitMQ',
@@ -76,6 +78,7 @@ RSpec.describe 'secrets' do
         ENV['ETL_QUEUE_CLASS'] = saved_queue_class
         ENV['ETL_DATABASE_PASSWORD'] = saved_db_password
         ENV['ETL_DATA_DIR'] = saved_data_dir
+        ENV['ETL_RABBIT_HOST'] = saved_host
       end
     end
   end


### PR DESCRIPTION
1) Fix name of rabbitmq user for env var
2) Update to not set amqp_uri if value doesn't exist
3) Update so ETL_CONFIG_DIR is only necessary if looking at files

[DW-570]