### PR TITLE
Fix bugs from redshift client refactor

### DIFF
--- a/lib/etl/s3/bucket_manager.rb
+++ b/lib/etl/s3/bucket_manager.rb
@@ -22,8 +22,7 @@ module ETL
           c_arr << f
         end
 
-        s3_files = []
-        files = local_filepaths.clone
+        s3_files = Concurrent::Array.new
         Thread.abort_on_exception = true
         @thread_count.times do |i|
           threads[i] = Thread.new do
@@ -34,7 +33,9 @@ module ETL
               next if size.zero?
 
               s3_file_name = File.basename(file)
-              ETL.logger.debug("[#{s3_file_name}] uploading...")
+
+              s3_path = "#{s3_file_name}/#{s3_folder}"
+              ETL.logger.debug("[Uploading from: '#{s3_file_name}' to '#{s3_path}']")
               s3_files << upload_file(file, s3_file_name, s3_folder)
             end
           end

--- a/spec/s3/csv_files_uploading_streamer_spec.rb
+++ b/spec/s3/csv_files_uploading_streamer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 's3' do
     let(:column_names_arr) { [orgs_column_names, org_history_column_names] }
     let(:table_names) { %w[orgs orgs_history] }
     it 'Validate then when size exceeds 5MBs the files are uploaded' do
-      test_writing_rows(100, 1)
+      test_writing_rows(100, 2)
     end
 
     it 'Write rows, never go over limit, validate no push' do
@@ -33,7 +33,7 @@ RSpec.describe 's3' do
     it 'Write rows, validate push end' do
       hash = test_writing_rows(50, 0)
       hash[:streamer].push_last
-      expect(hash[:bucket_manager].num_pushes).to eq(1)
+      expect(hash[:bucket_manager].num_pushes).to eq(2)
     end
 
     it 'Write rows, validate push end' do


### PR DESCRIPTION
1) skip if table rows=0 on upsert in redshift client
2) Use a concurrent array in bucketmanager to be thread safe
3) Change to ensure tables write to subfolder