### PR TITLE
Add UUID to queue payloads

### DIFF
--- a/lib/etl/queue/payload.rb
+++ b/lib/etl/queue/payload.rb
@@ -1,25 +1,29 @@
 require 'json'
 require 'etl/util/hash_util'
+require 'securerandom'
+
 module ETL::Queue
 
   # Class representing the payload we are putting into and off the job queue
   class Payload
-    attr_reader :job_id, :batch_hash
+    attr_reader :job_id, :batch_hash, :uuid
     
-    def initialize(job_id, batch)
+    def initialize(job_id, batch, uuid = SecureRandom.uuid)
       @job_id = job_id
       @batch_hash = batch.to_h
+      @uuid = uuid
     end
 
     def to_s
-      "Payload<job_id=#{@job_id}, batch=#{@batch_hash.to_s}>"
+      "Payload<uuid=#{@uuid}, job_id=#{@job_id}, batch=#{@batch_hash.to_s}>"
     end
     
     # encodes the payload into a string for storage in a queue
     def encode
       h = {
         :batch => @batch_hash,
-        :job_id => @job_id
+        :job_id => @job_id,
+        :uuid => @uuid
       }
       h.to_json.to_s
     end
@@ -28,7 +32,7 @@ module ETL::Queue
     # one that's been popped off a queue)
     def self.decode(str)
       h = ETL::HashUtil.symbolize_keys(JSON.parse(str))
-      ETL::Queue::Payload.new(h[:job_id], h[:batch])
+      ETL::Queue::Payload.new(h[:job_id], h[:batch], h[:uuid])
     end
   end
 end

--- a/spec/queue/payload_spec.rb
+++ b/spec/queue/payload_spec.rb
@@ -1,19 +1,58 @@
 require 'etl/queue/payload.rb'
 RSpec.describe "payload" do
 
-  it "makes round trip" do    
-    id = 123
-    batch = ETL::Batch.new({:foo => "abc", :bar => "xyz"})
-    
-    p = ETL::Queue::Payload.new(id, batch)
-    expect(p.to_s).to eq(<<STR.strip)
-Payload<job_id=123, batch={:bar=>"xyz", :foo=>"abc"}>
-STR
-    enc = p.encode
-    expect(enc).to eq('{"batch":{"bar":"xyz","foo":"abc"},"job_id":123}')
+  let(:id) { 123 }
+  let(:batch) { ETL::Batch.new({:foo => "abc", :bar => "xyz"}) }
+  let(:uuid) { 'baab7aea-39dd-4fdf-b6cd-6ec33a3dad38' }
+  let(:encoded_payload) { '{"batch":{"bar":"xyz","foo":"abc"},"job_id":123,"uuid":"baab7aea-39dd-4fdf-b6cd-6ec33a3dad38"}' }
 
-    p2 = ETL::Queue::Payload.decode(enc)
-    expect(p2.job_id).to eq(id)
-    expect(p2.batch_hash).to eq(batch.to_h)
+  context 'with no uuid specified' do
+    let(:uuid) { nil }
+
+    it 'creates a uuid' do
+      p = ETL::Queue::Payload.new(id, batch)
+      expect(p.uuid).not_to be_nil
+    end
+  end
+
+  describe 'encode' do
+    it 'encodes the correct values' do
+      p = ETL::Queue::Payload.new(id, batch, uuid)
+      enc = p.encode
+      expect(enc).to eq(encoded_payload)
+    end
+  end
+
+  describe 'decode' do
+    it 'decodes the correct values' do
+      p = ETL::Queue::Payload.decode(encoded_payload)
+      expect(p.job_id).to eq(id)
+      expect(p.batch_hash).to eq(batch.to_h)
+      expect(p.uuid).to eq(uuid)
+      expect(p.to_s).to eq('Payload<uuid=baab7aea-39dd-4fdf-b6cd-6ec33a3dad38, job_id=123, batch={:bar=>"xyz", :foo=>"abc"}>')
+    end
+
+    context 'with null uuid' do
+      let(:encoded_payload) { '{"batch":{"bar":"xyz","foo":"abc"},"job_id":123,"uuid":null}' }
+
+      it 'decodes the correct values' do
+        p = ETL::Queue::Payload.decode(encoded_payload)
+        expect(p.job_id).to eq(id)
+        expect(p.batch_hash).to eq(batch.to_h)
+        expect(p.uuid).to be_nil
+        expect(p.to_s).to eq('Payload<uuid=, job_id=123, batch={:bar=>"xyz", :foo=>"abc"}>')
+      end
+    end
+
+    context 'without uuid' do
+      let(:encoded_payload) { '{"batch":{"bar":"xyz","foo":"abc"},"job_id":123}' }
+      it 'decodes the correct values' do
+        p = ETL::Queue::Payload.decode(encoded_payload)
+        expect(p.job_id).to eq(id)
+        expect(p.batch_hash).to eq(batch.to_h)
+        expect(p.uuid).to be_nil
+        expect(p.to_s).to eq('Payload<uuid=, job_id=123, batch={:bar=>"xyz", :foo=>"abc"}>')
+      end
+    end
   end
 end


### PR DESCRIPTION
We have to ensure that multiple orgs jobs for the same bento don't run at the same time.

To ensure this, we can use a redis lock with the bento as the key.

However, when pods get rescheduled in the middle of a job, there is not a good way to unlock the job, because it could be in the middle of a long, expensive operation and will not be notified that the pod is going to terminate.

To get around this, we can publish each job with a uuid, and use it as the value when locking.  Then when a job tries to take a lock for a bento that is already locked, allow it to take over the lock, as this indicates that the message was redelivered from rabbit.