### PR TITLE
Add AZ64 encoding

### DIFF
--- a/lib/etl/redshift/table.rb
+++ b/lib/etl/redshift/table.rb
@@ -8,6 +8,7 @@ module ETL
         {
           "NONE" => [],
           "RAW" => ["ALL"],  # no compression
+          "AZ64" => ["SMALLINT", "INTEGER", "BIGINT", "DECIMAL", "DATE", "TIMESTAMP", "TIMESTAMPTZ"],
           "BYTEDICT" => ["ALL" ], # supports all types except bool
           "DELTA"	=> ["SMALLINT", "INT", "BIGINT", "DATE", "TIMESTAMP", "DECIMAL"],
           "DELTA32K" => ["INT", "BIGINT", "DATE", "TIMESTAMP", "DECIMAL"],

--- a/spec/s3/bucket_manager_spec.rb
+++ b/spec/s3/bucket_manager_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 's3' do
 
     def test_push(num_threads)
       s3_paths = []
-      bm = ::ETL::S3::BucketManager.new('test-s3-upload-bucket-1', 'us-west-2', num_threads)
-      s3_folder = SecureRandom.hex(8)
+      bm = ::ETL::S3::BucketManager.new(ETL.config.aws[:etl][:s3_bucket], ETL.config.aws[:etl][:region], num_threads)
+      s3_folder = "bucket_manager_test/#{SecureRandom.hex(8)}"
       begin
         csv_file_path1 = "valid_csv_1#{SecureRandom.hex(5)}"
         csv_file_path2 = "valid_csv_2#{SecureRandom.hex(5)}"


### PR DESCRIPTION
AZ64 encoding was added to redshift on 10/8/19 and is now
the default encoding for many datatypes.  let's support it.

https://aws.amazon.com/about-aws/whats-new/2019/10/amazon-redshift-introduces-az64-a-new-compression-encoding-for-optimized-storage-and-high-query-performance/

This also fixes a test that was hitting a strange s3 bucket, so that we can use the same access policies that we use for outreach-dw.